### PR TITLE
Allow gzip module to compress HTTP 207 Multi-Status responses

### DIFF
--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -228,7 +228,8 @@ ngx_http_gzip_header_filter(ngx_http_request_t *r)
     if (!conf->enable
         || (r->headers_out.status != NGX_HTTP_OK
             && r->headers_out.status != NGX_HTTP_FORBIDDEN
-            && r->headers_out.status != NGX_HTTP_NOT_FOUND)
+            && r->headers_out.status != NGX_HTTP_NOT_FOUND
+            && r->headers_out.status != NGX_HTTP_MULTI_STATUS)
         || (r->headers_out.content_encoding
             && r->headers_out.content_encoding->value.len)
         || (r->headers_out.content_length_n != -1

--- a/src/http/ngx_http_request.h
+++ b/src/http/ngx_http_request.h
@@ -79,6 +79,7 @@
 #define NGX_HTTP_ACCEPTED                  202
 #define NGX_HTTP_NO_CONTENT                204
 #define NGX_HTTP_PARTIAL_CONTENT           206
+#define NGX_HTTP_MULTI_STATUS              207
 
 #define NGX_HTTP_SPECIAL_RESPONSE          300
 #define NGX_HTTP_MOVED_PERMANENTLY         301


### PR DESCRIPTION
Added NGX_HTTP_MULTI_STATUS constant, reflecting HTTP status code 207

Данная проблема (недостаток) обсуждался на [trac' nginx'а](https://trac.nginx.org/nginx/ticket/394) ([ещё недавно всплыло на багтрекере Drupal](https://www.drupal.org/project/subrequests/issues/3281383)), но никто так патч и не применил.

Как было установлено в том же тикете на trac, всё склоняется к тому, "а не багануты ли" клиентские приложения. С тех пор прошло 10 лет, и вероятность существования приложений, которые бы отсылали `Accept-Encoding: gzip, deflate`, при этом не умея обрабатывать ответы сжатые последними, крайне мала.

Реальный пример использования: Nextcloud. Только вот, из-за данной недоработки в nginx (и возможно так же для "упрощения" настройки Apache), сам Nextcloud на стороне PHP кода сжимает ответы в gzip архивы (если присутствует `Accept-Encoding`), так как в противном случае создаётся огромный трафик между веб сервером и клиентом когда последний просто делает навигацию по папкам.