### PR TITLE
Добавлен вывод версии nginx в angie -V

### DIFF
--- a/src/core/nginx.c
+++ b/src/core/nginx.c
@@ -436,6 +436,7 @@ ngx_show_version_info(void)
     }
 
     if (ngx_show_configure) {
+        ngx_write_stderr("nginx version: " NGINX_VER_BUILD NGX_LINEFEED);
 
 #ifdef NGX_COMPILER
         ngx_write_stderr("built by " NGX_COMPILER NGX_LINEFEED);


### PR DESCRIPTION
Есть популярная штука, **certbot**, хотя вы и так знаете, если судить по домену, так вот, **certbot** нужен вывод версии **nginx**.

Собственно про чё я, есть одна противная [строка](https://github.com/certbot/certbot/blob/f4e031f5055fc6bf8c87eb0b18f927f7f5ba36a8/certbot-nginx/certbot_nginx/_internal/configurator.py#L1055), которая не даёт закостылить **certbot** под работу с **angie**, он вызывает `angie -V` и после в ответе ищет `nginx version:`, ну соответственно сыпется в ошибку, потому что там вместо неё вписана `Angie version:`. 

Ну я так прикинул, если это форк и там уже есть инфа о версии nginx, то почему бы ему её не вывести. Потестил у себя, работает, ну и вот, предлагаю теперь пулл реквест в массы.

Да и вроде по BSD-2 там должна быть инфа о nginx.

Сам костыль:

```
ln -s /etc/angie/angie.conf /etc/angie/nginx.conf
certbot --nginx-server-root=/etc/angie --nginx-ctl=angie
```

Пруф работы:

![image](https://github.com/webserver-llc/angie/assets/17812651/5e8f2b69-0713-49b7-81eb-8c7c32760938)