### PR TITLE
Added option for skipping check of client certificate time. 

### DIFF
--- a/src/event/ngx_event_openssl.c
+++ b/src/event/ngx_event_openssl.c
@@ -922,7 +922,7 @@ ngx_ssl_client_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *cert,
 
 ngx_int_t
 ngx_ssl_trusted_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *cert,
-    ngx_int_t depth)
+    ngx_int_t depth, ngx_uint_t no_check_time)
 {
     int              i, n;
     char            *err;
@@ -930,6 +930,10 @@ ngx_ssl_trusted_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *cert,
     X509_STORE      *store;
     STACK_OF(X509)  *chain;
 
+    if (no_check_time) {
+        X509_VERIFY_PARAM *vpm = SSL_CTX_get0_param(ssl->ctx);
+        X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_NO_CHECK_TIME);
+    }
     SSL_CTX_set_verify(ssl->ctx, SSL_CTX_get_verify_mode(ssl->ctx),
                        ngx_ssl_verify_callback);
 

--- a/src/event/ngx_event_openssl.h
+++ b/src/event/ngx_event_openssl.h
@@ -225,7 +225,7 @@ ngx_int_t ngx_ssl_ciphers(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *ciphers,
 ngx_int_t ngx_ssl_client_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_str_t *cert, ngx_int_t depth);
 ngx_int_t ngx_ssl_trusted_certificate(ngx_conf_t *cf, ngx_ssl_t *ssl,
-    ngx_str_t *cert, ngx_int_t depth);
+    ngx_str_t *cert, ngx_int_t depth, ngx_uint_t no_check_time);
 ngx_int_t ngx_ssl_crl(ngx_conf_t *cf, ngx_ssl_t *ssl, ngx_str_t *crl);
 ngx_int_t ngx_ssl_stapling(ngx_conf_t *cf, ngx_ssl_t *ssl,
     ngx_str_t *file, ngx_str_t *responder, ngx_uint_t verify);

--- a/src/http/modules/ngx_http_grpc_module.c
+++ b/src/http/modules/ngx_http_grpc_module.c
@@ -5011,7 +5011,8 @@ ngx_http_grpc_set_ssl(ngx_conf_t *cf, ngx_http_grpc_loc_conf_t *glcf)
 
         if (ngx_ssl_trusted_certificate(cf, glcf->upstream.ssl,
                                         &glcf->ssl_trusted_certificate,
-                                        glcf->ssl_verify_depth)
+                                        glcf->ssl_verify_depth,
+                                        glcf->no_check_time)
             != NGX_OK)
         {
             return NGX_ERROR;

--- a/src/http/modules/ngx_http_proxy_module.c
+++ b/src/http/modules/ngx_http_proxy_module.c
@@ -5859,7 +5859,8 @@ skip:
 
         if (ngx_ssl_trusted_certificate(cf, plcf->upstream.ssl,
                                         &plcf->ssl_trusted_certificate,
-                                        plcf->ssl_verify_depth)
+                                        plcf->ssl_verify_depth,
+                                        plcf->no_check_time)
             != NGX_OK)
         {
             return NGX_ERROR;

--- a/src/http/modules/ngx_http_ssl_module.c
+++ b/src/http/modules/ngx_http_ssl_module.c
@@ -187,6 +187,13 @@ static ngx_command_t  ngx_http_ssl_commands[] = {
       offsetof(ngx_http_ssl_srv_conf_t, verify_depth),
       NULL },
 
+    { ngx_string("ssl_no_check_time"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_ssl_srv_conf_t, no_check_time),
+      NULL },
+
     { ngx_string("ssl_client_certificate"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_str_slot,
@@ -652,6 +659,7 @@ ngx_http_ssl_create_srv_conf(ngx_conf_t *cf)
     sscf->buffer_size = NGX_CONF_UNSET_SIZE;
     sscf->verify = NGX_CONF_UNSET_UINT;
     sscf->verify_depth = NGX_CONF_UNSET_UINT;
+    sscf->no_check_time = NGX_CONF_UNSET;
     sscf->certificates = NGX_CONF_UNSET_PTR;
     sscf->certificate_keys = NGX_CONF_UNSET_PTR;
     sscf->passwords = NGX_CONF_UNSET_PTR;
@@ -697,6 +705,7 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_uint_value(conf->verify, prev->verify, 0);
     ngx_conf_merge_uint_value(conf->verify_depth, prev->verify_depth, 1);
+    ngx_conf_merge_value(conf->no_check_time, prev->no_check_time, 0);
 
     ngx_conf_merge_ptr_value(conf->certificates, prev->certificates, NULL);
     ngx_conf_merge_ptr_value(conf->certificate_keys, prev->certificate_keys,
@@ -848,7 +857,8 @@ ngx_http_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     if (ngx_ssl_trusted_certificate(cf, &conf->ssl,
                                     &conf->trusted_certificate,
-                                    conf->verify_depth)
+                                    conf->verify_depth,
+                                    conf->no_check_time)
         != NGX_OK)
     {
         return NGX_CONF_ERROR;

--- a/src/http/modules/ngx_http_ssl_module.h
+++ b/src/http/modules/ngx_http_ssl_module.h
@@ -26,6 +26,7 @@ typedef struct {
 
     ngx_uint_t                      verify;
     ngx_uint_t                      verify_depth;
+    ngx_flag_t                      no_check_time;
 
     size_t                          buffer_size;
 

--- a/src/http/modules/ngx_http_uwsgi_module.c
+++ b/src/http/modules/ngx_http_uwsgi_module.c
@@ -2620,7 +2620,8 @@ ngx_http_uwsgi_set_ssl(ngx_conf_t *cf, ngx_http_uwsgi_loc_conf_t *uwcf)
 
         if (ngx_ssl_trusted_certificate(cf, uwcf->upstream.ssl,
                                         &uwcf->ssl_trusted_certificate,
-                                        uwcf->ssl_verify_depth)
+                                        uwcf->ssl_verify_depth,
+                                        uwcf->no_check_time)
             != NGX_OK)
         {
             return NGX_ERROR;

--- a/src/mail/ngx_mail_ssl_module.c
+++ b/src/mail/ngx_mail_ssl_module.c
@@ -316,6 +316,7 @@ ngx_mail_ssl_create_conf(ngx_conf_t *cf)
     scf->prefer_server_ciphers = NGX_CONF_UNSET;
     scf->verify = NGX_CONF_UNSET_UINT;
     scf->verify_depth = NGX_CONF_UNSET_UINT;
+    scf->no_check_time = NGX_CONF_UNSET;
     scf->builtin_session_cache = NGX_CONF_UNSET;
     scf->session_timeout = NGX_CONF_UNSET;
     scf->session_tickets = NGX_CONF_UNSET;
@@ -468,7 +469,8 @@ ngx_mail_ssl_merge_conf(ngx_conf_t *cf, void *parent, void *child)
 
         if (ngx_ssl_trusted_certificate(cf, &conf->ssl,
                                         &conf->trusted_certificate,
-                                        conf->verify_depth)
+                                        conf->verify_depth,
+                                        conf->no_check_time)
             != NGX_OK)
         {
             return NGX_CONF_ERROR;

--- a/src/mail/ngx_mail_ssl_module.h
+++ b/src/mail/ngx_mail_ssl_module.h
@@ -30,6 +30,7 @@ typedef struct {
 
     ngx_uint_t       verify;
     ngx_uint_t       verify_depth;
+    ngx_flag_t       no_check_time;
 
     ssize_t          builtin_session_cache;
 

--- a/src/stream/ngx_stream_proxy_module.c
+++ b/src/stream/ngx_stream_proxy_module.c
@@ -2649,7 +2649,8 @@ ngx_stream_proxy_set_ssl(ngx_conf_t *cf, ngx_stream_proxy_srv_conf_t *pscf)
 
         if (ngx_ssl_trusted_certificate(cf, pscf->ssl,
                                         &pscf->ssl_trusted_certificate,
-                                        pscf->ssl_verify_depth)
+                                        pscf->ssl_verify_depth,
+                                        pscf->no_check_time)
             != NGX_OK)
         {
             return NGX_ERROR;

--- a/src/stream/ngx_stream_ssl_module.c
+++ b/src/stream/ngx_stream_ssl_module.c
@@ -940,6 +940,7 @@ ngx_stream_ssl_create_srv_conf(ngx_conf_t *cf)
     sscf->reject_handshake = NGX_CONF_UNSET;
     sscf->verify = NGX_CONF_UNSET_UINT;
     sscf->verify_depth = NGX_CONF_UNSET_UINT;
+    sscf->no_check_time = NGX_CONF_UNSET;
     sscf->builtin_session_cache = NGX_CONF_UNSET;
     sscf->session_timeout = NGX_CONF_UNSET;
     sscf->session_tickets = NGX_CONF_UNSET;
@@ -1124,7 +1125,8 @@ ngx_stream_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     if (ngx_ssl_trusted_certificate(cf, &conf->ssl,
                                     &conf->trusted_certificate,
-                                    conf->verify_depth)
+                                    conf->verify_depth,
+                                    conf->no_check_time)
         != NGX_OK)
     {
         return NGX_CONF_ERROR;

--- a/src/stream/ngx_stream_ssl_module.h
+++ b/src/stream/ngx_stream_ssl_module.h
@@ -27,6 +27,7 @@ typedef struct {
 
     ngx_uint_t       verify;
     ngx_uint_t       verify_depth;
+    ngx_flag_t       no_check_time;
 
     ssize_t          builtin_session_cache;
 


### PR DESCRIPTION
It may be old, but we should be able to check it.

We have a situation where we cannot change outdated certificates on already deployed devices.