### PR TITLE
Add overflow check to ngx_http_v3_parse_varlen_int()

### DIFF
--- a/src/http/v3/ngx_http_v3_parse.c
+++ b/src/http/v3/ngx_http_v3_parse.c
@@ -133,6 +133,11 @@ ngx_http_v3_parse_varlen_int(ngx_connection_t *c,
 
         case sw_length_2:
 
+            if (st->value > (UINT64_MAX >> 8)) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "http3 variable length integer overflow");
+                return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+            }
             st->value = (st->value << 8) + ch;
             if ((st->value & 0xc000) == 0x4000) {
                 st->value &= 0x3fff;
@@ -144,6 +149,11 @@ ngx_http_v3_parse_varlen_int(ngx_connection_t *c,
 
         case sw_length_4:
 
+            if (st->value > (UINT64_MAX >> 8)) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "http3 variable length integer overflow");
+                return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+            }
             st->value = (st->value << 8) + ch;
             if ((st->value & 0xc0000000) == 0x80000000) {
                 st->value &= 0x3fffffff;
@@ -158,12 +168,22 @@ ngx_http_v3_parse_varlen_int(ngx_connection_t *c,
         case sw_length_6:
         case sw_length_7:
 
+            if (st->value > (UINT64_MAX >> 8)) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "http3 variable length integer overflow");
+                return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+            }
             st->value = (st->value << 8) + ch;
             st->state++;
             break;
 
         case sw_length_8:
 
+            if (st->value > (UINT64_MAX >> 8)) {
+                ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                              "http3 variable length integer overflow");
+                return NGX_HTTP_V3_ERR_EXCESSIVE_LOAD;
+            }
             st->value = (st->value << 8) + ch;
             st->value &= 0x3fffffffffffffff;
             goto done;


### PR DESCRIPTION
This commit adds explicit integer overflow checking before left shift operations in the HTTP/3 variable-length integer parsing function.

While the current implementation has implicit protection via masking at line 168, adding explicit checks improves:
- Code clarity and maintainability
- Defense-in-depth security posture
- Early detection of overflow conditions
- Consistency with ngx_http_v3_parse_prefix_int() which has similar checks

The check prevents potential undefined behavior from left-shifting values that could overflow uint64_t boundaries.
## Security Note

**This is NOT a critical vulnerability fix.** The existing code has adequate 
protection via masking. This change improves code quality and defense-in-depth.

No CVE is being requested. This is a code hardening improvement discovered 
during security research.

## Additional Context

Full security research reports are available upon request.

We're happy to adjust the patch based on maintainer feedback.