### PR TITLE
Add zstd for access_log

### DIFF
--- a/auto/lib/conf
+++ b/auto/lib/conf
@@ -1,4 +1,4 @@
-
+# Copyright (C) 2026 Web Server LLC
 # Copyright (C) Igor Sysoev
 # Copyright (C) Nginx, Inc.
 

--- a/auto/lib/conf
+++ b/auto/lib/conf
@@ -29,6 +29,10 @@ if [ $USE_ZLIB = YES ]; then
     . auto/lib/zlib/conf
 fi
 
+if [ $USE_ZSTD = YES -o $ZSTD != NONE ]; then
+    . auto/lib/zstd/conf
+fi
+
 if [ $USE_LIBXSLT != NO ]; then
     . auto/lib/libxslt/conf
 fi

--- a/auto/lib/make
+++ b/auto/lib/make
@@ -1,4 +1,4 @@
-
+# Copyright (C) 2026 Web Server LLC
 # Copyright (C) Igor Sysoev
 # Copyright (C) Nginx, Inc.
 

--- a/auto/lib/make
+++ b/auto/lib/make
@@ -15,6 +15,10 @@ if [ $ZLIB != NONE -a $ZLIB != NO -a $ZLIB != YES ]; then
     . auto/lib/zlib/make
 fi
 
+if [ $ZSTD != NONE -a $ZSTD != NO -a $ZSTD != YES ]; then
+    . auto/lib/zstd/make
+fi
+
 if [ $NGX_LIBATOMIC != NO -a $NGX_LIBATOMIC != YES ]; then
     . auto/lib/libatomic/make
 fi

--- a/auto/lib/zstd/conf
+++ b/auto/lib/zstd/conf
@@ -1,0 +1,64 @@
+
+# Copyright (C) 2024 Web Server LLC
+# Copyright (C) Igor Sysoev
+# Copyright (C) Nginx, Inc.
+
+
+if [ $ZSTD != NONE ]; then
+    CORE_INCS="$CORE_INCS $ZSTD/include"
+
+    case "$NGX_CC_NAME" in
+
+        msvc | owc | bcc)
+            have=NGX_ZSTD . auto/have
+            LINK_DEPS="$LINK_DEPS $ZSTD/lib/libzstd.lib"
+            CORE_LIBS="$CORE_LIBS $ZSTD/lib/libzstd.lib"
+        ;;
+
+        *)
+            have=NGX_ZSTD . auto/have
+            LINK_DEPS="$LINK_DEPS $ZSTD/lib/libzstd.a"
+            CORE_LIBS="$CORE_LIBS $ZSTD/lib/libzstd.a"
+        ;;
+
+    esac
+
+else
+
+    if [ "$NGX_PLATFORM" != win32 ]; then
+        ZSTD=NO
+
+        # FreeBSD, Solaris, Linux
+
+        ngx_feature="zstd library"
+        ngx_feature_name="NGX_ZSTD"
+        ngx_feature_run=no
+        ngx_feature_incs="#include <zstd.h>"
+        ngx_feature_path=
+        ngx_feature_libs="-lzstd"
+        ngx_feature_test="size_t r = ZSTD_compress(NULL, 0, NULL, 0, 3);
+                          (void) ZSTD_isError(r)"
+        . auto/feature
+
+
+        if [ $ngx_found = yes ]; then
+            CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
+            ZSTD=YES
+            ngx_found=no
+        fi
+    fi
+
+    if [ $ZSTD != YES ]; then
+cat << END
+
+$0: error: the HTTP/stream log zstd module requires the libzstd library.
+You can either disable the module by using --without-http_log_zstd_module
+option, or install the libzstd library into the system, or build the libzstd
+library statically from the source with Angie by using --with-zstd=<path>
+option.
+
+END
+        exit 1
+    fi
+
+fi

--- a/auto/lib/zstd/conf
+++ b/auto/lib/zstd/conf
@@ -3,23 +3,11 @@
 
 
 if [ $ZSTD != NONE ]; then
+
     CORE_INCS="$CORE_INCS $ZSTD/include"
-
-    case "$NGX_CC_NAME" in
-
-        msvc | owc | bcc)
-            have=NGX_ZSTD . auto/have
-            LINK_DEPS="$LINK_DEPS $ZSTD/lib/libzstd.lib"
-            CORE_LIBS="$CORE_LIBS $ZSTD/lib/libzstd.lib"
-        ;;
-
-        *)
-            have=NGX_ZSTD . auto/have
-            LINK_DEPS="$LINK_DEPS $ZSTD/lib/libzstd.a"
-            CORE_LIBS="$CORE_LIBS $ZSTD/lib/libzstd.a"
-        ;;
-
-    esac
+    have=NGX_ZSTD . auto/have
+    LINK_DEPS="$LINK_DEPS $ZSTD/lib/libzstd.a"
+    CORE_LIBS="$CORE_LIBS $ZSTD/lib/libzstd.a"
 
 else
 

--- a/auto/lib/zstd/conf
+++ b/auto/lib/zstd/conf
@@ -1,5 +1,5 @@
 
-# Copyright (C) 2024 Web Server LLC
+# Copyright (C) 2026 Web Server LLC
 
 
 if [ $ZSTD != NONE ]; then
@@ -23,27 +23,25 @@ if [ $ZSTD != NONE ]; then
 
 else
 
-    if [ "$NGX_PLATFORM" != win32 ]; then
-        ZSTD=NO
+    ZSTD=NO
 
-        # FreeBSD, Solaris, Linux
+    # FreeBSD, Solaris, Linux
 
-        ngx_feature="zstd library"
-        ngx_feature_name="NGX_ZSTD"
-        ngx_feature_run=no
-        ngx_feature_incs="#include <zstd.h>"
-        ngx_feature_path=
-        ngx_feature_libs="-lzstd"
-        ngx_feature_test="size_t r = ZSTD_compress(NULL, 0, NULL, 0, 3);
-                          (void) ZSTD_isError(r)"
-        . auto/feature
+    ngx_feature="zstd library"
+    ngx_feature_name="NGX_ZSTD"
+    ngx_feature_run=no
+    ngx_feature_incs="#include <zstd.h>"
+    ngx_feature_path=
+    ngx_feature_libs="-lzstd"
+    ngx_feature_test="size_t r = ZSTD_compress(NULL, 0, NULL, 0, 3);
+                      (void) ZSTD_isError(r)"
+    . auto/feature
 
 
-        if [ $ngx_found = yes ]; then
-            CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
-            ZSTD=YES
-            ngx_found=no
-        fi
+    if [ $ngx_found = yes ]; then
+        CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
+        ZSTD=YES
+        ngx_found=no
     fi
 
     if [ $ZSTD != YES ]; then

--- a/auto/lib/zstd/conf
+++ b/auto/lib/zstd/conf
@@ -1,7 +1,5 @@
 
 # Copyright (C) 2024 Web Server LLC
-# Copyright (C) Igor Sysoev
-# Copyright (C) Nginx, Inc.
 
 
 if [ $ZSTD != NONE ]; then
@@ -52,10 +50,9 @@ else
 cat << END
 
 $0: error: the HTTP/stream log zstd module requires the libzstd library.
-You can either disable the module by using --without-http_log_zstd_module
-option, or install the libzstd library into the system, or build the libzstd
-library statically from the source with Angie by using --with-zstd=<path>
-option.
+You can either disable the module, or install the libzstd library into 
+the system, or build the libzstd library statically from the source 
+with Angie by using --with-zstd=<path> option.
 
 END
         exit 1

--- a/auto/lib/zstd/make
+++ b/auto/lib/zstd/make
@@ -1,7 +1,5 @@
 
 # Copyright (C) 2024 Web Server LLC
-# Copyright (C) Igor Sysoev
-# Copyright (C) Nginx, Inc.
 
 
 # Build libzstd from sources when --with-zstd=DIR was given.

--- a/auto/lib/zstd/make
+++ b/auto/lib/zstd/make
@@ -1,28 +1,11 @@
 
-# Copyright (C) 2024 Web Server LLC
+# Copyright (C) 2026 Web Server LLC
 
 
 # Build libzstd from sources when --with-zstd=DIR was given.
 # Mirrors auto/lib/zlib/make but uses zstd's native "libzstd.a" target
 # rather than a configure script (libzstd does not need one).
 
-case "$NGX_PLATFORM" in
-
-    win32)
-        # On Windows, fall back to the user's pre-built import library
-        # if it already exists in the expected location, otherwise try
-        # to build the DLL via the upstream Makefile (mingw-cross).
-        cat << END                                        >> $NGX_MAKEFILE
-
-`echo "$ZSTD/lib/libzstd.lib:  $NGX_MAKEFILE" | sed -e "s/\//$ngx_regex_dirsep/g"`
-	cd $ZSTD \\
-	&& \$(MAKE) -C lib lib-release \\
-		CFLAGS="$ZSTD_OPT" CC="\$(CC)"
-
-END
-    ;;
-
-    *)
         cat << END                                        >> $NGX_MAKEFILE
 
 $ZSTD/lib/libzstd.a:	$NGX_MAKEFILE
@@ -31,6 +14,3 @@ $ZSTD/lib/libzstd.a:	$NGX_MAKEFILE
 		CFLAGS="$ZSTD_OPT" CC="\$(CC)"
 
 END
-    ;;
-
-esac

--- a/auto/lib/zstd/make
+++ b/auto/lib/zstd/make
@@ -1,0 +1,38 @@
+
+# Copyright (C) 2024 Web Server LLC
+# Copyright (C) Igor Sysoev
+# Copyright (C) Nginx, Inc.
+
+
+# Build libzstd from sources when --with-zstd=DIR was given.
+# Mirrors auto/lib/zlib/make but uses zstd's native "libzstd.a" target
+# rather than a configure script (libzstd does not need one).
+
+case "$NGX_PLATFORM" in
+
+    win32)
+        # On Windows, fall back to the user's pre-built import library
+        # if it already exists in the expected location, otherwise try
+        # to build the DLL via the upstream Makefile (mingw-cross).
+        cat << END                                        >> $NGX_MAKEFILE
+
+`echo "$ZSTD/lib/libzstd.lib:  $NGX_MAKEFILE" | sed -e "s/\//$ngx_regex_dirsep/g"`
+	cd $ZSTD \\
+	&& \$(MAKE) -C lib lib-release \\
+		CFLAGS="$ZSTD_OPT" CC="\$(CC)"
+
+END
+    ;;
+
+    *)
+        cat << END                                        >> $NGX_MAKEFILE
+
+$ZSTD/lib/libzstd.a:	$NGX_MAKEFILE
+	cd $ZSTD \\
+	&& \$(MAKE) -C lib libzstd.a \\
+		CFLAGS="$ZSTD_OPT" CC="\$(CC)"
+
+END
+    ;;
+
+esac

--- a/auto/options
+++ b/auto/options
@@ -190,6 +190,7 @@ ZLIB_ASM=NO
 
 USE_ZSTD=NO
 ZSTD=NONE
+ZSTD_OPT=
 
 USE_PERL=NO
 NGX_PERL=perl
@@ -463,6 +464,7 @@ $0: warning: the \"--with-sha1-asm\" option is deprecated"
 
         --with-zstd)                     USE_ZSTD=YES               ;;
         --with-zstd=*)                   ZSTD="$value"              ;;
+        --with-zstd-opt=*)               ZSTD_OPT="$value"          ;;
 
         --with-libatomic)                NGX_LIBATOMIC=YES          ;;
         --with-libatomic=*)              NGX_LIBATOMIC="$value"     ;;
@@ -687,6 +689,7 @@ cat << END
   --with-zstd                        enable zstd compression support
                                      for access_log (uses system libzstd)
   --with-zstd=DIR                    set path to libzstd library sources
+  --with-zstd-opt=OPTIONS            set additional build options for libzstd
 
   --with-libatomic                   force libatomic_ops library usage
   --with-libatomic=DIR               set path to libatomic_ops library sources

--- a/auto/options
+++ b/auto/options
@@ -188,6 +188,9 @@ ZLIB=NONE
 ZLIB_OPT=
 ZLIB_ASM=NO
 
+USE_ZSTD=NO
+ZSTD=NONE
+
 USE_PERL=NO
 NGX_PERL=perl
 
@@ -458,6 +461,9 @@ $0: warning: the \"--with-sha1-asm\" option is deprecated"
         --with-zlib-opt=*)               ZLIB_OPT="$value"          ;;
         --with-zlib-asm=*)               ZLIB_ASM="$value"          ;;
 
+        --with-zstd)                     USE_ZSTD=YES               ;;
+        --with-zstd=*)                   ZSTD="$value"              ;;
+
         --with-libatomic)                NGX_LIBATOMIC=YES          ;;
         --with-libatomic=*)              NGX_LIBATOMIC="$value"     ;;
 
@@ -677,6 +683,10 @@ cat << END
   --with-zlib-asm=CPU                use zlib assembler sources optimized
                                      for the specified CPU, valid values:
                                      pentium, pentiumpro
+
+  --with-zstd                        enable zstd compression support
+                                     for access_log (uses system libzstd)
+  --with-zstd=DIR                    set path to libzstd library sources
 
   --with-libatomic                   force libatomic_ops library usage
   --with-libatomic=DIR               set path to libatomic_ops library sources

--- a/auto/summary
+++ b/auto/summary
@@ -34,6 +34,12 @@ case $ZLIB in
     *)     echo "  + using zlib library: $ZLIB" ;;
 esac
 
+case $ZSTD in
+    YES)   echo "  + using system zstd library" ;;
+    NONE)  echo "  + zstd library is not used" ;;
+    *)     echo "  + using zstd library: $ZSTD" ;;
+esac
+
 case $NGX_LIBATOMIC in
     YES)   echo "  + using system libatomic_ops library" ;;
     NO)    ;; # not used

--- a/docs/xml/angie/changes.xml
+++ b/docs/xml/angie/changes.xml
@@ -9,37 +9,22 @@
 
 <change type="feature">
 <para lang="ru">
-Сжатие логов доступа в формате zstd с помощью параметра zstd[=уровень].
-Уровень может принимать значение от 1 до 22. Уровни >= 20
-следует использовать с осторожностью, так как они требуют больше памяти.
-По умолчанию используется буфер размером 64 КБ и уровень сжатия 3.
-Сжатие выполняется атомарно, по одному zstd-фрейму на каждую запись буфера.
-В любой момент времени лог-файл может быть распакован или прочитан
-с помощью утилиты zstdcat.
-
-Для сборки с поддержкой zstd предназначена опция --with-zstd (системная
-библиотека libzstd) или --with-zstd=DIR (сборка из исходников).
-Для передачи дополнительных флагов компиляции при сборке из исходников
-предусмотрена опция --with-zstd-opt=OPTIONS.
-
-Пример использования:
-access_log /path/to/log.zstd combined buffer=64k zstd=5 flush=5m;
+Сжатие логов доступа на лету в формате zstd с помощью параметра "zstd[=уровень]"
+директивы "access_log" в модулях http и stream;
+сжатие выполняется атомарно, по одному zstd-фрейму на каждую запись буфера,
+аналогично существующей поддержке gzip;
+для сборки с поддержкой zstd предназначена опция "--with-zstd" (системная
+библиотека libzstd) или "--with-zstd=DIR" (сборка из исходников) опцилнально
+для компиляции "--with-zstd-opt=OPTIONS" (опции при компиляции исходников).
 </para>
 <para lang="en">
-Access log compression in zstd format using the zstd[=level] parameter.
-The level can take values from 1 to 22. Levels >= 20
-should be used with caution, as they require more memory.
-By default, a 64 KB buffer and compression level 3 are used.
-Compression is performed atomically, one zstd frame per buffer write.
-At any time, the log file can be decompressed or read using the zstdcat utility.
-
-To build with zstd support, use the --with-zstd option (system libzstd
-library) or --with-zstd=DIR (build from source).
-To pass additional compilation flags when building from source,
-use the --with-zstd-opt=OPTIONS option.
-
-Usage example:
-access_log /path/to/log.zstd combined buffer=64k zstd=5 flush=5m;
+On-the-fly zstd compression of access logs via the "zstd[=level]" parameter
+of the "access_log" directive in the http and stream modules;
+compression is atomic, with one zstd frame per buffer flush, mirroring the
+existing gzip support;
+the "--with-zstd" configure option (system libzstd) or "--with-zstd=DIR"
+(build from sources) enables zstd support optional for source compilation
+"--with-zstd-opt=OPTIONS" (compilation options).
 </para>
 </change>
   

--- a/docs/xml/angie/changes.xml
+++ b/docs/xml/angie/changes.xml
@@ -9,16 +9,16 @@
 
 <change type="feature">
 <para lang="ru">
-сжатие логов доступа на лету в формате zstd с помощью параметра "zstd[=уровень]"
+Сжатие логов доступа на лету в формате zstd с помощью параметра "zstd[=уровень]"
 директивы "access_log" в модулях http и stream;
 сжатие выполняется атомарно, по одному zstd-фрейму на каждую запись буфера,
 аналогично существующей поддержке gzip;
 для сборки с поддержкой zstd предназначена опция "--with-zstd" (системная
-библиотека libzstd) или "--with-zstd=DIR" (сборка из исходников) опцилнально 
+библиотека libzstd) или "--with-zstd=DIR" (сборка из исходников) опцилнально
 для компиляции "--with-zstd-opt=OPTIONS" (опции при компиляции исходников).
 </para>
 <para lang="en">
-on-the-fly zstd compression of access logs via the "zstd[=level]" parameter
+On-the-fly zstd compression of access logs via the "zstd[=level]" parameter
 of the "access_log" directive in the http and stream modules;
 compression is atomic, with one zstd frame per buffer flush, mirroring the
 existing gzip support;
@@ -27,6 +27,24 @@ the "--with-zstd" configure option (system libzstd) or "--with-zstd=DIR"
 "--with-zstd-opt=OPTIONS" (compilation options).
 </para>
 </change>
+
+<change type="bugfix">
+<para lang="ru">
+Let's Encrypt завершал ACME ALPN-верификацию для IP-адресов с сообщением об
+ошибке "Incorrect validation certificate for tls-alpn-01 challenge ... wrong
+number of identifiers".
+</para>
+<para lang="en">
+Let's Encrypt failed the TLS-ALPN-01 challenge for an IP address identifier
+with the error message: "Incorrect validation certificate for tls-alpn-01
+challenge ... wrong number of identifiers".
+</para>
+</change>
+
+</changes>
+
+
+<changes ver="1.12.1" date="2026-07-17">
 
 <change type="security">
 <para lang="ru">

--- a/docs/xml/angie/changes.xml
+++ b/docs/xml/angie/changes.xml
@@ -5,7 +5,28 @@
 <change_log title="Angie">
 
 
-<changes ver="1.12.1" date="2026-07-17">
+<changes ver="1.13.0" date="">
+
+<change type="feature">
+<para lang="ru">
+сжатие логов доступа на лету в формате zstd с помощью параметра "zstd[=уровень]"
+директивы "access_log" в модулях http и stream;
+сжатие выполняется атомарно, по одному zstd-фрейму на каждую запись буфера,
+аналогично существующей поддержке gzip;
+для сборки с поддержкой zstd предназначена опция "--with-zstd" (системная
+библиотека libzstd) или "--with-zstd=DIR" (сборка из исходников) опцилнально 
+для компиляции "--with-zstd-opt=OPTIONS" (опции при компиляции исходников).
+</para>
+<para lang="en">
+on-the-fly zstd compression of access logs via the "zstd[=level]" parameter
+of the "access_log" directive in the http and stream modules;
+compression is atomic, with one zstd frame per buffer flush, mirroring the
+existing gzip support;
+the "--with-zstd" configure option (system libzstd) or "--with-zstd=DIR"
+(build from sources) enables zstd support optional for source compilation
+"--with-zstd-opt=OPTIONS" (compilation options).
+</para>
+</change>
 
 <change type="security">
 <para lang="ru">

--- a/docs/xml/angie/changes.xml
+++ b/docs/xml/angie/changes.xml
@@ -9,22 +9,37 @@
 
 <change type="feature">
 <para lang="ru">
-Сжатие логов доступа на лету в формате zstd с помощью параметра "zstd[=уровень]"
-директивы "access_log" в модулях http и stream;
-сжатие выполняется атомарно, по одному zstd-фрейму на каждую запись буфера,
-аналогично существующей поддержке gzip;
-для сборки с поддержкой zstd предназначена опция "--with-zstd" (системная
-библиотека libzstd) или "--with-zstd=DIR" (сборка из исходников) опцилнально
-для компиляции "--with-zstd-opt=OPTIONS" (опции при компиляции исходников).
+Сжатие логов доступа в формате zstd с помощью параметра zstd[=уровень].
+Уровень может принимать значение от 1 до 22. Уровни >= 20
+следует использовать с осторожностью, так как они требуют больше памяти.
+По умолчанию используется буфер размером 64 КБ и уровень сжатия 3.
+Сжатие выполняется атомарно, по одному zstd-фрейму на каждую запись буфера.
+В любой момент времени лог-файл может быть распакован или прочитан
+с помощью утилиты zstdcat.
+
+Для сборки с поддержкой zstd предназначена опция --with-zstd (системная
+библиотека libzstd) или --with-zstd=DIR (сборка из исходников).
+Для передачи дополнительных флагов компиляции при сборке из исходников
+предусмотрена опция --with-zstd-opt=OPTIONS.
+
+Пример использования:
+access_log /path/to/log.zstd combined buffer=64k zstd=5 flush=5m;
 </para>
 <para lang="en">
-On-the-fly zstd compression of access logs via the "zstd[=level]" parameter
-of the "access_log" directive in the http and stream modules;
-compression is atomic, with one zstd frame per buffer flush, mirroring the
-existing gzip support;
-the "--with-zstd" configure option (system libzstd) or "--with-zstd=DIR"
-(build from sources) enables zstd support optional for source compilation
-"--with-zstd-opt=OPTIONS" (compilation options).
+Access log compression in zstd format using the zstd[=level] parameter.
+The level can take values from 1 to 22. Levels >= 20
+should be used with caution, as they require more memory.
+By default, a 64 KB buffer and compression level 3 are used.
+Compression is performed atomically, one zstd frame per buffer write.
+At any time, the log file can be decompressed or read using the zstdcat utility.
+
+To build with zstd support, use the --with-zstd option (system libzstd
+library) or --with-zstd=DIR (build from source).
+To pass additional compilation flags when building from source,
+use the --with-zstd-opt=OPTIONS option.
+
+Usage example:
+access_log /path/to/log.zstd combined buffer=64k zstd=5 flush=5m;
 </para>
 </change>
   

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -1,5 +1,6 @@
 
 /*
+ * Copyright (C) 2026 Web Server LLC
  * Copyright (C) Igor Sysoev
  * Copyright (C) Nginx, Inc.
  */
@@ -1441,8 +1442,8 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_script_compile_t          sc;
     ngx_http_compile_complex_value_t   ccv;
 #if (NGX_ZLIB || NGX_ZSTD)
-    ngx_http_log_compress_pt           compress = NULL;
-    ngx_int_t                          comp_level = 0;
+    ngx_http_log_compress_pt           compress;
+    ngx_int_t                          comp_level;
 #endif
 
     value = cf->args->elts;
@@ -1556,6 +1557,10 @@ process_formats:
 
     size = 0;
     flush = 0;
+#if (NGX_ZLIB || NGX_ZSTD)
+    compress = NULL;
+    comp_level = 0;
+#endif    
 
     for (i = 3; i < cf->args->nelts; i++) {
 

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -48,6 +48,10 @@ typedef struct {
 } ngx_http_log_main_conf_t;
 
 
+typedef ssize_t (*ngx_http_log_compress_pt)(ngx_fd_t fd, u_char *buf,
+    size_t len, ngx_int_t level, ngx_log_t *log);
+
+
 typedef struct {
     u_char                     *start;
     u_char                     *pos;
@@ -55,8 +59,8 @@ typedef struct {
 
     ngx_event_t                *event;
     ngx_msec_t                  flush;
-    ngx_int_t                   gzip;
-    ngx_int_t                   zstd;
+    ngx_http_log_compress_pt    compress;
+    ngx_int_t                   comp_level;
 } ngx_http_log_buf_t;
 
 
@@ -429,23 +433,16 @@ ngx_http_log_write(ngx_http_request_t *r, ngx_http_log_t *log, u_char *buf,
 
 #if (NGX_ZLIB || NGX_ZSTD)
         buffer = log->file->data;
-#endif
 
-#if (NGX_ZSTD)
-        if (buffer && buffer->zstd) {
-            n = ngx_http_log_zstd(log->file->fd, buf, len, buffer->zstd,
-                                  r->connection->log);
-        } else
-#endif
-#if (NGX_ZLIB)
-        if (buffer && buffer->gzip) {
-            n = ngx_http_log_gzip(log->file->fd, buf, len, buffer->gzip,
-                                  r->connection->log);
-        } else
-#endif
-        {
+        if (buffer && buffer->compress) {
+            n = buffer->compress(log->file->fd, buf, len,
+                                 buffer->comp_level, r->connection->log);
+        } else {
             n = ngx_write_fd(log->file->fd, buf, len);
         }
+#else
+        n = ngx_write_fd(log->file->fd, buf, len);
+#endif
 
     } else {
         name = NULL;
@@ -819,14 +816,10 @@ ngx_http_log_flush(ngx_open_file_t *file, ngx_log_t *log)
         return;
     }
 
-#if (NGX_ZSTD)
-    if (buffer->zstd) {
-        n = ngx_http_log_zstd(file->fd, buffer->start, len, buffer->zstd, log);
-    } else
-#endif
-#if (NGX_ZLIB)
-    if (buffer->gzip) {
-        n = ngx_http_log_gzip(file->fd, buffer->start, len, buffer->gzip, log);
+#if (NGX_ZLIB || NGX_ZSTD)
+    if (buffer->compress) {
+        n = buffer->compress(file->fd, buffer->start, len,
+                             buffer->comp_level, log);
     } else
 #endif
     {
@@ -1435,8 +1428,7 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_log_loc_conf_t *llcf = conf;
 
     ssize_t                            size;
-    ngx_int_t                          gzip;
-    ngx_int_t                          zstd;
+    ngx_int_t                          comp_level;
     ngx_uint_t                         i, n;
     ngx_msec_t                         flush;
     ngx_str_t                         *value, name, s;
@@ -1447,6 +1439,11 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_log_main_conf_t          *lmcf;
     ngx_http_script_compile_t          sc;
     ngx_http_compile_complex_value_t   ccv;
+#if (NGX_ZLIB || NGX_ZSTD)
+    ngx_http_log_compress_pt           compress = NULL;
+#else
+    void                              *compress = NULL;
+#endif
 
     value = cf->args->elts;
 
@@ -1559,8 +1556,7 @@ process_formats:
 
     size = 0;
     flush = 0;
-    gzip = 0;
-    zstd = 0;
+    comp_level = 0;
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1598,26 +1594,35 @@ process_formats:
             && (value[i].len == 4 || value[i].data[4] == '='))
         {
 #if (NGX_ZLIB)
+            if (compress) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "duplicate compression method "
+                                   "in access_log \"%V\"", &value[1]);
+                return NGX_CONF_ERROR;
+            }
+
             if (size == 0) {
                 size = 64 * 1024;
             }
 
             if (value[i].len == 4) {
-                gzip = Z_BEST_SPEED;
+                comp_level = Z_BEST_SPEED;
+                compress = ngx_http_log_gzip;
                 continue;
             }
 
             s.len = value[i].len - 5;
             s.data = value[i].data + 5;
 
-            gzip = ngx_atoi(s.data, s.len);
+            comp_level = ngx_atoi(s.data, s.len);
 
-            if (gzip < 1 || gzip > 9) {
+            if (comp_level < 1 || comp_level > 9) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "invalid compression level \"%V\"", &s);
                 return NGX_CONF_ERROR;
             }
 
+            compress = ngx_http_log_gzip;
             continue;
 
 #else
@@ -1631,26 +1636,35 @@ process_formats:
             && (value[i].len == 4 || value[i].data[4] == '='))
         {
 #if (NGX_ZSTD)
+            if (compress) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "duplicate compression method "
+                                   "in access_log \"%V\"", &value[1]);
+                return NGX_CONF_ERROR;
+            }
+
             if (size == 0) {
                 size = 64 * 1024;
             }
 
             if (value[i].len == 4) {
-                zstd = ZSTD_CLEVEL_DEFAULT;
+                comp_level = ZSTD_CLEVEL_DEFAULT;
+                compress = ngx_http_log_zstd;
                 continue;
             }
 
             s.len = value[i].len - 5;
             s.data = value[i].data + 5;
 
-            zstd = ngx_atoi(s.data, s.len);
+            comp_level = ngx_atoi(s.data, s.len);
 
-            if (zstd < 1 || zstd > ZSTD_maxCLevel()) {
+            if (comp_level < 1 || comp_level > ZSTD_maxCLevel()) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "invalid compression level \"%V\"", &s);
                 return NGX_CONF_ERROR;
             }
 
+            compress = ngx_http_log_zstd;
             continue;
 
 #else
@@ -1714,8 +1728,8 @@ process_formats:
 
             if (buffer->last - buffer->start != size
                 || buffer->flush != flush
-                || buffer->gzip != gzip
-                || buffer->zstd != zstd)
+                || buffer->compress != compress
+                || buffer->comp_level != comp_level)
             {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "access_log \"%V\" already defined "
@@ -1754,8 +1768,8 @@ process_formats:
             buffer->flush = flush;
         }
 
-        buffer->gzip = gzip;
-        buffer->zstd = zstd;
+        buffer->compress = compress;
+        buffer->comp_level = comp_level;
 
         log->file->flush = ngx_http_log_flush;
         log->file->data = buffer;

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -13,6 +13,10 @@
 #include <zlib.h>
 #endif
 
+#if (NGX_ZSTD)
+#include <zstd.h>
+#endif
+
 
 typedef struct ngx_http_log_op_s  ngx_http_log_op_t;
 
@@ -52,6 +56,7 @@ typedef struct {
     ngx_event_t                *event;
     ngx_msec_t                  flush;
     ngx_int_t                   gzip;
+    ngx_int_t                   zstd;
 } ngx_http_log_buf_t;
 
 
@@ -106,6 +111,11 @@ static ssize_t ngx_http_log_gzip(ngx_fd_t fd, u_char *buf, size_t len,
 
 static void *ngx_http_log_gzip_alloc(void *opaque, u_int items, u_int size);
 static void ngx_http_log_gzip_free(void *opaque, void *address);
+#endif
+
+#if (NGX_ZSTD)
+static ssize_t ngx_http_log_zstd(ngx_fd_t fd, u_char *buf, size_t len,
+    ngx_int_t level, ngx_log_t *log);
 #endif
 
 static void ngx_http_log_flush(ngx_open_file_t *file, ngx_log_t *log);
@@ -410,25 +420,32 @@ ngx_http_log_write(ngx_http_request_t *r, ngx_http_log_t *log, u_char *buf,
     time_t               now;
     ssize_t              n;
     ngx_err_t            err;
-#if (NGX_ZLIB)
+#if (NGX_ZLIB || NGX_ZSTD)
     ngx_http_log_buf_t  *buffer;
 #endif
 
     if (log->script == NULL) {
         name = log->file->name.data;
 
-#if (NGX_ZLIB)
+#if (NGX_ZLIB || NGX_ZSTD)
         buffer = log->file->data;
+#endif
 
+#if (NGX_ZSTD)
+        if (buffer && buffer->zstd) {
+            n = ngx_http_log_zstd(log->file->fd, buf, len, buffer->zstd,
+                                  r->connection->log);
+        } else
+#endif
+#if (NGX_ZLIB)
         if (buffer && buffer->gzip) {
             n = ngx_http_log_gzip(log->file->fd, buf, len, buffer->gzip,
                                   r->connection->log);
-        } else {
+        } else
+#endif
+        {
             n = ngx_write_fd(log->file->fd, buf, len);
         }
-#else
-        n = ngx_write_fd(log->file->fd, buf, len);
-#endif
 
     } else {
         name = NULL;
@@ -715,6 +732,78 @@ ngx_http_log_gzip_free(void *opaque, void *address)
 #endif
 
 
+#if (NGX_ZSTD)
+
+static ssize_t
+ngx_http_log_zstd(ngx_fd_t fd, u_char *buf, size_t len, ngx_int_t level,
+    ngx_log_t *log)
+{
+    u_char      *out;
+    size_t       size, zret;
+    ssize_t      n;
+    ngx_err_t    err;
+    ngx_pool_t  *pool;
+
+    /*
+     * Allocate the worst-case output buffer reported by ZSTD_compressBound().
+     * zstd does not need a deflate-style wrapper, so no extra bytes are added.
+     * The whole compressed frame is then written in a single ngx_write_fd()
+     * call to preserve atomicity, exactly like ngx_http_log_gzip() does.
+     */
+
+    size = ZSTD_compressBound(len);
+
+    pool = ngx_create_pool(256, log);
+    if (pool == NULL) {
+        /* simulate successful logging */
+        return len;
+    }
+
+    pool->log = log;
+
+    out = ngx_pnalloc(pool, size);
+    if (out == NULL) {
+        goto done;
+    }
+
+    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, log, 0,
+                   "zstd compress: len:%uz bound:%uz level:%i",
+                   len, size, level);
+
+    zret = ZSTD_compress(out, size, buf, len, (int) level);
+
+    if (ZSTD_isError(zret)) {
+        ngx_log_error(NGX_LOG_ALERT, log, 0,
+                      "ZSTD_compress() failed: %s",
+                      ZSTD_getErrorName(zret));
+        goto done;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
+                   "zstd compressed: in:%uz out:%uz", len, zret);
+
+    n = ngx_write_fd(fd, out, zret);
+
+    if (n != (ssize_t) zret) {
+        err = (n == -1) ? ngx_errno : 0;
+
+        ngx_destroy_pool(pool);
+
+        ngx_set_errno(err);
+        return -1;
+    }
+
+done:
+
+    ngx_destroy_pool(pool);
+
+    /* simulate successful logging */
+    return len;
+}
+
+#endif
+
+
 static void
 ngx_http_log_flush(ngx_open_file_t *file, ngx_log_t *log)
 {
@@ -730,15 +819,19 @@ ngx_http_log_flush(ngx_open_file_t *file, ngx_log_t *log)
         return;
     }
 
+#if (NGX_ZSTD)
+    if (buffer->zstd) {
+        n = ngx_http_log_zstd(file->fd, buffer->start, len, buffer->zstd, log);
+    } else
+#endif
 #if (NGX_ZLIB)
     if (buffer->gzip) {
         n = ngx_http_log_gzip(file->fd, buffer->start, len, buffer->gzip, log);
-    } else {
+    } else
+#endif
+    {
         n = ngx_write_fd(file->fd, buffer->start, len);
     }
-#else
-    n = ngx_write_fd(file->fd, buffer->start, len);
-#endif
 
     if (n == -1) {
         ngx_log_error(NGX_LOG_ALERT, log, ngx_errno,
@@ -1343,6 +1436,7 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ssize_t                            size;
     ngx_int_t                          gzip;
+    ngx_int_t                          zstd;
     ngx_uint_t                         i, n;
     ngx_msec_t                         flush;
     ngx_str_t                         *value, name, s;
@@ -1466,6 +1560,7 @@ process_formats:
     size = 0;
     flush = 0;
     gzip = 0;
+    zstd = 0;
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1532,6 +1627,39 @@ process_formats:
 #endif
         }
 
+        if (ngx_strncmp(value[i].data, "zstd", 4) == 0
+            && (value[i].len == 4 || value[i].data[4] == '='))
+        {
+#if (NGX_ZSTD)
+            if (size == 0) {
+                size = 64 * 1024;
+            }
+
+            if (value[i].len == 4) {
+                zstd = ZSTD_CLEVEL_DEFAULT;
+                continue;
+            }
+
+            s.len = value[i].len - 5;
+            s.data = value[i].data + 5;
+
+            zstd = ngx_atoi(s.data, s.len);
+
+            if (zstd < 1 || zstd > ZSTD_maxCLevel()) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "invalid compression level \"%V\"", &s);
+                return NGX_CONF_ERROR;
+            }
+
+            continue;
+
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "Angie was built without zstd support");
+            return NGX_CONF_ERROR;
+#endif
+        }
+
         if (ngx_strncmp(value[i].data, "if=", 3) == 0) {
             s.len = value[i].len - 3;
             s.data = value[i].data + 3;
@@ -1586,7 +1714,8 @@ process_formats:
 
             if (buffer->last - buffer->start != size
                 || buffer->flush != flush
-                || buffer->gzip != gzip)
+                || buffer->gzip != gzip
+                || buffer->zstd != zstd)
             {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "access_log \"%V\" already defined "
@@ -1626,6 +1755,7 @@ process_formats:
         }
 
         buffer->gzip = gzip;
+        buffer->zstd = zstd;
 
         log->file->flush = ngx_http_log_flush;
         log->file->data = buffer;

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -59,8 +59,10 @@ typedef struct {
 
     ngx_event_t                *event;
     ngx_msec_t                  flush;
+#if (NGX_ZLIB || NGX_ZSTD)
     ngx_http_log_compress_pt    compress;
     ngx_int_t                   comp_level;
+#endif
 } ngx_http_log_buf_t;
 
 

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -1609,9 +1609,10 @@ process_formats:
                 size = 64 * 1024;
             }
 
+            compress = ngx_http_log_gzip;
+
             if (value[i].len == 4) {
                 comp_level = Z_BEST_SPEED;
-                compress = ngx_http_log_gzip;
                 continue;
             }
 
@@ -1626,7 +1627,6 @@ process_formats:
                 return NGX_CONF_ERROR;
             }
 
-            compress = ngx_http_log_gzip;
             continue;
 
 #else
@@ -1651,9 +1651,10 @@ process_formats:
                 size = 64 * 1024;
             }
 
+            compress = ngx_http_log_zstd;
+
             if (value[i].len == 4) {
                 comp_level = ZSTD_CLEVEL_DEFAULT;
-                compress = ngx_http_log_zstd;
                 continue;
             }
 
@@ -1668,7 +1669,6 @@ process_formats:
                 return NGX_CONF_ERROR;
             }
 
-            compress = ngx_http_log_zstd;
             continue;
 
 #else

--- a/src/http/modules/ngx_http_log_module.c
+++ b/src/http/modules/ngx_http_log_module.c
@@ -1428,7 +1428,6 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_log_loc_conf_t *llcf = conf;
 
     ssize_t                            size;
-    ngx_int_t                          comp_level;
     ngx_uint_t                         i, n;
     ngx_msec_t                         flush;
     ngx_str_t                         *value, name, s;
@@ -1441,8 +1440,7 @@ ngx_http_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_compile_complex_value_t   ccv;
 #if (NGX_ZLIB || NGX_ZSTD)
     ngx_http_log_compress_pt           compress = NULL;
-#else
-    void                              *compress = NULL;
+    ngx_int_t                          comp_level = 0;
 #endif
 
     value = cf->args->elts;
@@ -1556,7 +1554,6 @@ process_formats:
 
     size = 0;
     flush = 0;
-    comp_level = 0;
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1728,8 +1725,11 @@ process_formats:
 
             if (buffer->last - buffer->start != size
                 || buffer->flush != flush
+#if (NGX_ZLIB || NGX_ZSTD)
                 || buffer->compress != compress
-                || buffer->comp_level != comp_level)
+                || buffer->comp_level != comp_level
+#endif
+            )
             {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "access_log \"%V\" already defined "
@@ -1768,8 +1768,10 @@ process_formats:
             buffer->flush = flush;
         }
 
+#if (NGX_ZLIB || NGX_ZSTD)
         buffer->compress = compress;
         buffer->comp_level = comp_level;
+#endif
 
         log->file->flush = ngx_http_log_flush;
         log->file->data = buffer;

--- a/src/stream/ngx_stream_log_module.c
+++ b/src/stream/ngx_stream_log_module.c
@@ -13,6 +13,10 @@
 #include <zlib.h>
 #endif
 
+#if (NGX_ZSTD)
+#include <zstd.h>
+#endif
+
 
 typedef struct ngx_stream_log_op_s  ngx_stream_log_op_t;
 
@@ -51,6 +55,7 @@ typedef struct {
     ngx_event_t                 *event;
     ngx_msec_t                   flush;
     ngx_int_t                    gzip;
+    ngx_int_t                    zstd;
 } ngx_stream_log_buf_t;
 
 
@@ -105,6 +110,11 @@ static ssize_t ngx_stream_log_gzip(ngx_fd_t fd, u_char *buf, size_t len,
 
 static void *ngx_stream_log_gzip_alloc(void *opaque, u_int items, u_int size);
 static void ngx_stream_log_gzip_free(void *opaque, void *address);
+#endif
+
+#if (NGX_ZSTD)
+static ssize_t ngx_stream_log_zstd(ngx_fd_t fd, u_char *buf, size_t len,
+    ngx_int_t level, ngx_log_t *log);
 #endif
 
 static void ngx_stream_log_flush(ngx_open_file_t *file, ngx_log_t *log);
@@ -358,25 +368,32 @@ ngx_stream_log_write(ngx_stream_session_t *s, ngx_stream_log_t *log,
     time_t                 now;
     ssize_t                n;
     ngx_err_t              err;
-#if (NGX_ZLIB)
+#if (NGX_ZLIB || NGX_ZSTD)
     ngx_stream_log_buf_t  *buffer;
 #endif
 
     if (log->script == NULL) {
         name = log->file->name.data;
 
-#if (NGX_ZLIB)
+#if (NGX_ZLIB || NGX_ZSTD)
         buffer = log->file->data;
+#endif
 
+#if (NGX_ZSTD)
+        if (buffer && buffer->zstd) {
+            n = ngx_stream_log_zstd(log->file->fd, buf, len, buffer->zstd,
+                                    s->connection->log);
+        } else
+#endif
+#if (NGX_ZLIB)
         if (buffer && buffer->gzip) {
             n = ngx_stream_log_gzip(log->file->fd, buf, len, buffer->gzip,
                                     s->connection->log);
-        } else {
+        } else
+#endif
+        {
             n = ngx_write_fd(log->file->fd, buf, len);
         }
-#else
-        n = ngx_write_fd(log->file->fd, buf, len);
-#endif
 
     } else {
         name = NULL;
@@ -607,6 +624,78 @@ ngx_stream_log_gzip_free(void *opaque, void *address)
 #endif
 
 
+#if (NGX_ZSTD)
+
+static ssize_t
+ngx_stream_log_zstd(ngx_fd_t fd, u_char *buf, size_t len, ngx_int_t level,
+    ngx_log_t *log)
+{
+    u_char      *out;
+    size_t       size, zret;
+    ssize_t      n;
+    ngx_err_t    err;
+    ngx_pool_t  *pool;
+
+    /*
+     * Allocate the worst-case output buffer reported by ZSTD_compressBound().
+     * zstd does not need a deflate-style wrapper, so no extra bytes are added.
+     * The whole compressed frame is then written in a single ngx_write_fd()
+     * call to preserve atomicity, exactly like ngx_stream_log_gzip() does.
+     */
+
+    size = ZSTD_compressBound(len);
+
+    pool = ngx_create_pool(256, log);
+    if (pool == NULL) {
+        /* simulate successful logging */
+        return len;
+    }
+
+    pool->log = log;
+
+    out = ngx_pnalloc(pool, size);
+    if (out == NULL) {
+        goto done;
+    }
+
+    ngx_log_debug3(NGX_LOG_DEBUG_STREAM, log, 0,
+                   "zstd compress: len:%uz bound:%uz level:%i",
+                   len, size, level);
+
+    zret = ZSTD_compress(out, size, buf, len, (int) level);
+
+    if (ZSTD_isError(zret)) {
+        ngx_log_error(NGX_LOG_ALERT, log, 0,
+                      "ZSTD_compress() failed: %s",
+                      ZSTD_getErrorName(zret));
+        goto done;
+    }
+
+    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, log, 0,
+                   "zstd compressed: in:%uz out:%uz", len, zret);
+
+    n = ngx_write_fd(fd, out, zret);
+
+    if (n != (ssize_t) zret) {
+        err = (n == -1) ? ngx_errno : 0;
+
+        ngx_destroy_pool(pool);
+
+        ngx_set_errno(err);
+        return -1;
+    }
+
+done:
+
+    ngx_destroy_pool(pool);
+
+    /* simulate successful logging */
+    return len;
+}
+
+#endif
+
+
 static void
 ngx_stream_log_flush(ngx_open_file_t *file, ngx_log_t *log)
 {
@@ -622,16 +711,21 @@ ngx_stream_log_flush(ngx_open_file_t *file, ngx_log_t *log)
         return;
     }
 
+#if (NGX_ZSTD)
+    if (buffer->zstd) {
+        n = ngx_stream_log_zstd(file->fd, buffer->start, len, buffer->zstd,
+                                log);
+    } else
+#endif
 #if (NGX_ZLIB)
     if (buffer->gzip) {
         n = ngx_stream_log_gzip(file->fd, buffer->start, len, buffer->gzip,
                                 log);
-    } else {
+    } else
+#endif
+    {
         n = ngx_write_fd(file->fd, buffer->start, len);
     }
-#else
-    n = ngx_write_fd(file->fd, buffer->start, len);
-#endif
 
     if (n == -1) {
         ngx_log_error(NGX_LOG_ALERT, log, ngx_errno,
@@ -1029,6 +1123,7 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     ssize_t                              size;
     ngx_int_t                            gzip;
+    ngx_int_t                            zstd;
     ngx_uint_t                           i, n;
     ngx_msec_t                           flush;
     ngx_str_t                           *value, name, s;
@@ -1149,6 +1244,7 @@ process_formats:
     size = 0;
     flush = 0;
     gzip = 0;
+    zstd = 0;
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1215,6 +1311,39 @@ process_formats:
 #endif
         }
 
+        if (ngx_strncmp(value[i].data, "zstd", 4) == 0
+            && (value[i].len == 4 || value[i].data[4] == '='))
+        {
+#if (NGX_ZSTD)
+            if (size == 0) {
+                size = 64 * 1024;
+            }
+
+            if (value[i].len == 4) {
+                zstd = ZSTD_CLEVEL_DEFAULT;
+                continue;
+            }
+
+            s.len = value[i].len - 5;
+            s.data = value[i].data + 5;
+
+            zstd = ngx_atoi(s.data, s.len);
+
+            if (zstd < 1 || zstd > ZSTD_maxCLevel()) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "invalid compression level \"%V\"", &s);
+                return NGX_CONF_ERROR;
+            }
+
+            continue;
+
+#else
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                               "Angie was built without zstd support");
+            return NGX_CONF_ERROR;
+#endif
+        }
+
         if (ngx_strncmp(value[i].data, "if=", 3) == 0) {
             s.len = value[i].len - 3;
             s.data = value[i].data + 3;
@@ -1269,7 +1398,8 @@ process_formats:
 
             if (buffer->last - buffer->start != size
                 || buffer->flush != flush
-                || buffer->gzip != gzip)
+                || buffer->gzip != gzip
+                || buffer->zstd != zstd)
             {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "access_log \"%V\" already defined "
@@ -1309,6 +1439,7 @@ process_formats:
         }
 
         buffer->gzip = gzip;
+        buffer->zstd = zstd;
 
         log->file->flush = ngx_stream_log_flush;
         log->file->data = buffer;

--- a/src/stream/ngx_stream_log_module.c
+++ b/src/stream/ngx_stream_log_module.c
@@ -58,8 +58,10 @@ typedef struct {
 
     ngx_event_t                 *event;
     ngx_msec_t                   flush;
+#if (NGX_ZLIB || NGX_ZSTD)
     ngx_stream_log_compress_pt   compress;
     ngx_int_t                    comp_level;
+#endif
 } ngx_stream_log_buf_t;
 
 

--- a/src/stream/ngx_stream_log_module.c
+++ b/src/stream/ngx_stream_log_module.c
@@ -1,5 +1,6 @@
 
 /*
+ * Copyright (C) 2026 Web Server LLC
  * Copyright (C) Igor Sysoev
  * Copyright (C) Nginx, Inc.
  */
@@ -1126,8 +1127,8 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_stream_log_main_conf_t          *lmcf;
     ngx_stream_compile_complex_value_t   ccv;
 #if (NGX_ZLIB || NGX_ZSTD)
-    ngx_stream_log_compress_pt           compress = NULL;
-    ngx_int_t                            comp_level = 0;
+    ngx_stream_log_compress_pt           compress;
+    ngx_int_t                            comp_level;
 #endif
 
     value = cf->args->elts;
@@ -1238,6 +1239,10 @@ process_formats:
 
     size = 0;
     flush = 0;
+#if (NGX_ZLIB || NGX_ZSTD)
+    compress = NULL;
+    comp_level = 0;
+#endif    
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1286,9 +1291,10 @@ process_formats:
                 size = 64 * 1024;
             }
 
+            compress = ngx_stream_log_gzip;
+
             if (value[i].len == 4) {
                 comp_level = Z_BEST_SPEED;
-                compress = ngx_stream_log_gzip;
                 continue;
             }
 
@@ -1303,7 +1309,6 @@ process_formats:
                 return NGX_CONF_ERROR;
             }
 
-            compress = ngx_stream_log_gzip;
             continue;
 
 #else
@@ -1328,9 +1333,10 @@ process_formats:
                 size = 64 * 1024;
             }
 
+            compress = ngx_stream_log_zstd;
+
             if (value[i].len == 4) {
                 comp_level = ZSTD_CLEVEL_DEFAULT;
-                compress = ngx_stream_log_zstd;
                 continue;
             }
 
@@ -1345,7 +1351,6 @@ process_formats:
                 return NGX_CONF_ERROR;
             }
 
-            compress = ngx_stream_log_zstd;
             continue;
 
 #else

--- a/src/stream/ngx_stream_log_module.c
+++ b/src/stream/ngx_stream_log_module.c
@@ -47,6 +47,10 @@ typedef struct {
 } ngx_stream_log_main_conf_t;
 
 
+typedef ssize_t (*ngx_stream_log_compress_pt)(ngx_fd_t fd, u_char *buf,
+    size_t len, ngx_int_t level, ngx_log_t *log);
+
+
 typedef struct {
     u_char                      *start;
     u_char                      *pos;
@@ -54,8 +58,8 @@ typedef struct {
 
     ngx_event_t                 *event;
     ngx_msec_t                   flush;
-    ngx_int_t                    gzip;
-    ngx_int_t                    zstd;
+    ngx_stream_log_compress_pt   compress;
+    ngx_int_t                    comp_level;
 } ngx_stream_log_buf_t;
 
 
@@ -377,23 +381,16 @@ ngx_stream_log_write(ngx_stream_session_t *s, ngx_stream_log_t *log,
 
 #if (NGX_ZLIB || NGX_ZSTD)
         buffer = log->file->data;
-#endif
 
-#if (NGX_ZSTD)
-        if (buffer && buffer->zstd) {
-            n = ngx_stream_log_zstd(log->file->fd, buf, len, buffer->zstd,
-                                    s->connection->log);
-        } else
-#endif
-#if (NGX_ZLIB)
-        if (buffer && buffer->gzip) {
-            n = ngx_stream_log_gzip(log->file->fd, buf, len, buffer->gzip,
-                                    s->connection->log);
-        } else
-#endif
-        {
+        if (buffer && buffer->compress) {
+            n = buffer->compress(log->file->fd, buf, len,
+                                 buffer->comp_level, s->connection->log);
+        } else {
             n = ngx_write_fd(log->file->fd, buf, len);
         }
+#else
+        n = ngx_write_fd(log->file->fd, buf, len);
+#endif
 
     } else {
         name = NULL;
@@ -711,16 +708,10 @@ ngx_stream_log_flush(ngx_open_file_t *file, ngx_log_t *log)
         return;
     }
 
-#if (NGX_ZSTD)
-    if (buffer->zstd) {
-        n = ngx_stream_log_zstd(file->fd, buffer->start, len, buffer->zstd,
-                                log);
-    } else
-#endif
-#if (NGX_ZLIB)
-    if (buffer->gzip) {
-        n = ngx_stream_log_gzip(file->fd, buffer->start, len, buffer->gzip,
-                                log);
+#if (NGX_ZLIB || NGX_ZSTD)
+    if (buffer->compress) {
+        n = buffer->compress(file->fd, buffer->start, len,
+                             buffer->comp_level, log);
     } else
 #endif
     {
@@ -1122,8 +1113,7 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_stream_log_srv_conf_t *lscf = conf;
 
     ssize_t                              size;
-    ngx_int_t                            gzip;
-    ngx_int_t                            zstd;
+    ngx_int_t                            comp_level;
     ngx_uint_t                           i, n;
     ngx_msec_t                           flush;
     ngx_str_t                           *value, name, s;
@@ -1134,6 +1124,11 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_stream_script_compile_t          sc;
     ngx_stream_log_main_conf_t          *lmcf;
     ngx_stream_compile_complex_value_t   ccv;
+#if (NGX_ZLIB || NGX_ZSTD)
+    ngx_stream_log_compress_pt           compress = NULL;
+#else
+    void                                *compress = NULL;
+#endif
 
     value = cf->args->elts;
 
@@ -1243,8 +1238,7 @@ process_formats:
 
     size = 0;
     flush = 0;
-    gzip = 0;
-    zstd = 0;
+    comp_level = 0;
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1282,26 +1276,35 @@ process_formats:
             && (value[i].len == 4 || value[i].data[4] == '='))
         {
 #if (NGX_ZLIB)
+            if (compress) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "duplicate compression method "
+                                   "in access_log \"%V\"", &value[1]);
+                return NGX_CONF_ERROR;
+            }
+
             if (size == 0) {
                 size = 64 * 1024;
             }
 
             if (value[i].len == 4) {
-                gzip = Z_BEST_SPEED;
+                comp_level = Z_BEST_SPEED;
+                compress = ngx_stream_log_gzip;
                 continue;
             }
 
             s.len = value[i].len - 5;
             s.data = value[i].data + 5;
 
-            gzip = ngx_atoi(s.data, s.len);
+            comp_level = ngx_atoi(s.data, s.len);
 
-            if (gzip < 1 || gzip > 9) {
+            if (comp_level < 1 || comp_level > 9) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "invalid compression level \"%V\"", &s);
                 return NGX_CONF_ERROR;
             }
 
+            compress = ngx_stream_log_gzip;
             continue;
 
 #else
@@ -1315,26 +1318,35 @@ process_formats:
             && (value[i].len == 4 || value[i].data[4] == '='))
         {
 #if (NGX_ZSTD)
+            if (compress) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                                   "duplicate compression method "
+                                   "in access_log \"%V\"", &value[1]);
+                return NGX_CONF_ERROR;
+            }
+
             if (size == 0) {
                 size = 64 * 1024;
             }
 
             if (value[i].len == 4) {
-                zstd = ZSTD_CLEVEL_DEFAULT;
+                comp_level = ZSTD_CLEVEL_DEFAULT;
+                compress = ngx_stream_log_zstd;
                 continue;
             }
 
             s.len = value[i].len - 5;
             s.data = value[i].data + 5;
 
-            zstd = ngx_atoi(s.data, s.len);
+            comp_level = ngx_atoi(s.data, s.len);
 
-            if (zstd < 1 || zstd > ZSTD_maxCLevel()) {
+            if (comp_level < 1 || comp_level > ZSTD_maxCLevel()) {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "invalid compression level \"%V\"", &s);
                 return NGX_CONF_ERROR;
             }
 
+            compress = ngx_stream_log_zstd;
             continue;
 
 #else
@@ -1398,8 +1410,8 @@ process_formats:
 
             if (buffer->last - buffer->start != size
                 || buffer->flush != flush
-                || buffer->gzip != gzip
-                || buffer->zstd != zstd)
+                || buffer->compress != compress
+                || buffer->comp_level != comp_level)
             {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "access_log \"%V\" already defined "
@@ -1438,8 +1450,8 @@ process_formats:
             buffer->flush = flush;
         }
 
-        buffer->gzip = gzip;
-        buffer->zstd = zstd;
+        buffer->compress = compress;
+        buffer->comp_level = comp_level;
 
         log->file->flush = ngx_stream_log_flush;
         log->file->data = buffer;

--- a/src/stream/ngx_stream_log_module.c
+++ b/src/stream/ngx_stream_log_module.c
@@ -1113,7 +1113,6 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_stream_log_srv_conf_t *lscf = conf;
 
     ssize_t                              size;
-    ngx_int_t                            comp_level;
     ngx_uint_t                           i, n;
     ngx_msec_t                           flush;
     ngx_str_t                           *value, name, s;
@@ -1126,8 +1125,7 @@ ngx_stream_log_set_log(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_stream_compile_complex_value_t   ccv;
 #if (NGX_ZLIB || NGX_ZSTD)
     ngx_stream_log_compress_pt           compress = NULL;
-#else
-    void                                *compress = NULL;
+    ngx_int_t                            comp_level = 0;
 #endif
 
     value = cf->args->elts;
@@ -1238,7 +1236,6 @@ process_formats:
 
     size = 0;
     flush = 0;
-    comp_level = 0;
 
     for (i = 3; i < cf->args->nelts; i++) {
 
@@ -1410,8 +1407,11 @@ process_formats:
 
             if (buffer->last - buffer->start != size
                 || buffer->flush != flush
+#if (NGX_ZLIB || NGX_ZSTD)
                 || buffer->compress != compress
-                || buffer->comp_level != comp_level)
+                || buffer->comp_level != comp_level
+#endif
+            )
             {
                 ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                                    "access_log \"%V\" already defined "
@@ -1450,8 +1450,10 @@ process_formats:
             buffer->flush = flush;
         }
 
+#if (NGX_ZLIB || NGX_ZSTD)
         buffer->compress = compress;
         buffer->comp_level = comp_level;
+#endif
 
         log->file->flush = ngx_stream_log_flush;
         log->file->data = buffer;


### PR DESCRIPTION
Good afternoon! 
Please accept the addition of the ability to save the access_log file in zstd format, similar to gzip, 
I tried to take into account the existing architecture of this application.

The binary file is assembled, conducted a smoke test on both one and one worker and on multiple, the log file is read and written adequately in both versions. The compression settings and buffer size are identical to gzip files.  
The build is done using the ./configure ... --with-zstd or --with-zstd={path/to/lib} key. 
Output example: 
"access_log  /var/log/angie/access.log.zstd  combined  buffer=64k  flush=1s  zstd=3;"