### PR TITLE
Upstream: fixed status retries for non-idempotent requests

### DIFF
--- a/src/http/ngx_http_upstream.c
+++ b/src/http/ngx_http_upstream.c
@@ -3227,7 +3227,7 @@ static ngx_int_t
 ngx_http_upstream_test_next(ngx_http_request_t *r, ngx_http_upstream_t *u)
 {
     ngx_msec_t                 timeout;
-    ngx_uint_t                 status;
+    ngx_uint_t                 status, mask;
     ngx_http_upstream_next_t  *un;
 
     status = u->headers_in.status_n;
@@ -3240,19 +3240,19 @@ ngx_http_upstream_test_next(ngx_http_request_t *r, ngx_http_upstream_t *u)
 
         timeout = u->conf->next_upstream_timeout;
 
-        if ((u->conf->next_upstream & un->mask)
+        if (u->request_sent
+            && (r->method & (NGX_HTTP_POST|NGX_HTTP_LOCK|NGX_HTTP_PATCH)))
+        {
+            mask = un->mask | NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT;
+
+        } else {
+            mask = un->mask;
+        }
+
+        if (((u->conf->next_upstream & mask) == mask)
             && !(u->request_sent && r->request_body_no_buffering)
             && !(timeout && ngx_current_msec - u->peer.start_time >= timeout))
         {
-
-            if (u->request_sent
-                && (r->method & (NGX_HTTP_POST|NGX_HTTP_LOCK|NGX_HTTP_PATCH))
-                && !(u->conf->next_upstream
-                     & NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT))
-            {
-                return NGX_OK;
-            }
-
             ngx_http_upstream_next(r, u, un->mask);
             return NGX_OK;
         }


### PR DESCRIPTION
### Problem

Since Angie 1.11.0, HTTP status-based `proxy_next_upstream` handling is broken for POST, LOCK, and PATCH requests after the request has already been sent to an upstream and `non_idempotent` is not configured.

When an upstream returns a status configured in `proxy_next_upstream`, `ngx_http_upstream_test_next()` enters the retry path, but returns `NGX_OK` when retrying a non-idempotent request is prohibited.

The caller interprets `NGX_OK` as the response being fully handled and stops processing it.  As a result, the request is not retried, but the original upstream error response is not processed either.

For example:

```nginx
proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
```

with:

```text
POST -> upstream -> 500
```

and without `non_idempotent` does not retry the POST, as expected, but also fails to return the original 500 response correctly.

### Cause

This behavior was introduced by the changes to `ngx_http_upstream_test_next()` in Angie 1.11.0.

Previously, non-idempotent requests added `NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT` to the mask used to decide whether `ngx_http_upstream_next()` could be called.

The new implementation performs this check after matching the HTTP status and returns `NGX_OK` when retrying is prohibited.

### Fix

Restore the mask-based check for `NGX_HTTP_UPSTREAM_FT_NON_IDEMPOTENT`.

The `u->peer.tries > 1` condition from the old implementation is intentionally not restored, preserving the Angie 1.11+ behavior where an Angie-generated error response is used when all upstream peers have been exhausted.

This also allows the existing `cache_use_stale` handling to remain reachable when retrying a non-idempotent request is prohibited.

### Expected behavior

Without `non_idempotent`:

```text
POST -> upstream1 -> 500
client <- 500
```

The request must not be sent to another upstream.

With `non_idempotent`:

```text
POST -> upstream1 -> 500
     -> upstream2 -> 200
client <- 200
```

Idempotent requests continue to use the existing `proxy_next_upstream` behavior.

### How to reproduce

The issue can be reproduced with the following Docker Compose setup:

```yaml
# test requests
#
### GET - angie and nginx - OK
#
# curl -sv --max-time 6 http://127.0.0.1:8080/
# curl -sv --max-time 6 http://127.0.0.1:8081/
#
### POST - angie bug
#
# curl -sv --max-time 6 -X POST -d 'foo=bar' http://127.0.0.1:8080/
# curl -sv --max-time 6 -X POST -d 'foo=bar' http://127.0.0.1:8081/
#
# LOGS
#
### angie
#
# 172.23.0.1 [04/Sep/2026:13:30:29 +0000] "GET / HTTP/1.1" status=200 request_id=f9361100323906ebecd047f79481d090 request_time=0.001 upstream_addr="172.23.0.5:80, 172.23.0.4:80" upstream_status="500, 200" upstream_connect_time="0.000, 0.000" upstream_header_time="0.000, 0.001" upstream_response_time="0.000, 0.001"
# 2026/09/04 13:31:14 [error] 11#11: *4 upstream timed out (110: Operation timed out) while reading response header from upstream, client: "172.23.0.1", server: "", request_line: "POST / HTTP/1.1", upstream: "http://172.23.0.5:80/", host: "127.0.0.1:8080"
# 172.23.0.1 [04/Sep/2026:13:31:14 +0000] "POST / HTTP/1.1" status=504 request_id=c152cb9bd1323ead1971abde01044495 request_time=3.003 upstream_addr="172.23.0.5:80" upstream_status="504" upstream_connect_time="0.001" upstream_header_time="0.001" upstream_response_time="3.004"
#
### nginx
#
# 172.23.0.1 [04/Sep/2026:13:30:58 +0000] "GET / HTTP/1.1" status=200 request_id=3479fddfe6573f124fcc4ed3b6d6fd4d request_time=0.001 upstream_addr="172.23.0.5:80, 172.23.0.4:80" upstream_status="500, 200" upstream_connect_time="0.000, 0.000" upstream_header_time="0.000, 0.001" upstream_response_time="0.000, 0.001"
# 172.23.0.1 [04/Sep/2026:13:31:31 +0000] "POST / HTTP/1.1" status=500 request_id=9307ef300cbc737d3556e080c9ff8c4e request_time=0.001 upstream_addr="172.23.0.5:80" upstream_status="500" upstream_connect_time="0.000" upstream_header_time="0.000" upstream_response_time="0.000"
#
---
name: angie-next-upstream-bug

services:
  backend200:
    image: nginx:1.30-alpine
    restart: unless-stopped
    configs:
      - source: 200_conf
        target: /etc/nginx/conf.d/default.conf

  backend500:
    image: nginx:1.30-alpine
    restart: unless-stopped
    configs:
      - source: 500_conf
        target: /etc/nginx/conf.d/default.conf

  angie:
    image: docker.angie.software/angie:1.12.1-minimal
    restart: unless-stopped
    ports:
      - "127.0.0.1:8080:80"
    configs:
      - source: proxy_conf
        target: /etc/angie/http.d/default.conf

  nginx:
    image: nginx:1.30-alpine
    restart: unless-stopped
    ports:
      - "127.0.0.1:8081:80"
    configs:
      - source: proxy_conf
        target: /etc/nginx/conf.d/default.conf

configs:
  200_conf:
    content: |
      server {
        listen 80;
        location / {
          add_header X-Backend backend200 always;
          return 200 "OK\n";
        }
      }

  500_conf:
    content: |
      server {
        listen 80;
        location / {
          add_header X-Backend backend500 always;
          return 500 "ERROR\n";
        }
      }

  proxy_conf:
    content: |
      log_format upstream_debug
        '$$remote_addr [$$time_local] '
        '"$$request" '
        'status=$$status '
        'request_id=$$request_id '
        'request_time=$$request_time '
        'upstream_addr="$$upstream_addr" '
        'upstream_status="$$upstream_status" '
        'upstream_connect_time="$$upstream_connect_time" '
        'upstream_header_time="$$upstream_header_time" '
        'upstream_response_time="$$upstream_response_time"';
      upstream backend {
        server backend500:80 max_fails=0;
        server backend200:80 backup;
      }
      server {
        listen 80;
        access_log /dev/stdout upstream_debug;
        location / {
          proxy_pass http://backend;
          proxy_set_header X-Request-ID $$request_id;
          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
          proxy_next_upstream_tries 2;
          proxy_connect_timeout 1s;
          proxy_send_timeout 3s;
          proxy_read_timeout 3s;
          add_header X-Debug-Request-ID $$request_id always;
          add_header X-Debug-Upstream-Addr $$upstream_addr always;
          add_header X-Debug-Upstream-Status $$upstream_status always;
          add_header X-Debug-Upstream-Response-Time $$upstream_response_time always;
        }
      }
```

